### PR TITLE
change infoButtonView Text font

### DIFF
--- a/Teslanyse/Views/Data Views/AutomotiveSalesView.swift
+++ b/Teslanyse/Views/Data Views/AutomotiveSalesView.swift
@@ -37,7 +37,7 @@ struct AutomotiveSalesView: View {
                 .pickerStyle(.palette)
             Divider()
             Text("Accumulated")
-                .font(.headline)
+                .font(.title2)
                 .padding(.horizontal)
             PickerView<SelectionYesNo>(selection: $selectionAccumulated)
                 .pickerStyle(.palette)

--- a/Teslanyse/Views/Data Views/SuperchargerView.swift
+++ b/Teslanyse/Views/Data Views/SuperchargerView.swift
@@ -29,8 +29,8 @@ struct SuperchargerView: View {
                 .pickerStyle(.palette)
             Divider()
             Text("Accumulated") // Explicitly add the label here
-                .font(.headline)
-                .padding(.horizontal)            
+                .font(.title2)
+                .padding(.horizontal)
             PickerView<SelectionYesNo>(selection: $selectionAccumulated)
                 .pickerStyle(.palette)
             ExportButtonView()

--- a/Teslanyse/Views/Reusable UI Components/UIElements.swift
+++ b/Teslanyse/Views/Reusable UI Components/UIElements.swift
@@ -63,7 +63,7 @@ struct InfoButtonView<InfoView: View>: View {
     var body: some View {
         HStack {
             Text(title) // Explicitly add the label here
-                .font(.headline)
+                .font(.title2)
                 .padding(.horizontal)
             Spacer()
             NavigationLink(destination: infoView) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the font size of text elements in Automotive Sales and Supercharger views from `.headline` to `.title2`.
- **New Features**
	- Added an `Export Button` in the Supercharger view.
- **Refactor**
	- Adjusted horizontal padding in the Supercharger view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->